### PR TITLE
DomStyleWrapper typing compatible with noImplicitAny

### DIFF
--- a/dom/dom-style.ts
+++ b/dom/dom-style.ts
@@ -22,4 +22,6 @@ export class DomStyleWrapper implements CS.OneJS.Dom.DomStyle {
     }
 }
 
-export interface DomStyleWrapper extends CS.OneJS.Dom.DomStyle { }
+export interface DomStyleWrapper extends CS.OneJS.Dom.DomStyle {
+    [key: string | symbol]: any;
+}


### PR DESCRIPTION
With `noImplicitAny: true` in `tsconfig.json`, the current type results in a tsc error because DomStyleWrapper doesn't have an indexing signature defined.